### PR TITLE
(fix) add plugin assembly id for newer maven

### DIFF
--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <assembly>
+    <id>release</id>
     <formats>
         <format>zip</format>
     </formats>


### PR DESCRIPTION
see https://github.com/medcl/elasticsearch-analysis-ik/issues/208