### PR TITLE
修复 parentDict 导致的 NPE

### DIFF
--- a/src/main/java/com/chenlb/mmseg4j/Dictionary.java
+++ b/src/main/java/com/chenlb/mmseg4j/Dictionary.java
@@ -534,9 +534,13 @@ public class Dictionary {
 
     private CharNode getCharNode(char key) {
         CharNode ret = dict.get(key);
-        if (ret == null)
-            ret = parentDict.get(key);
-        return ret;
+        if (ret != null) return ret;
+        if (parentDict != null) {
+            return parentDict.get(key);
+        } else {
+            log.info("CharNode starting with '" + key + "' for dict " + appId + " not found.");
+            return ret;
+        }
     }
 
 


### PR DESCRIPTION
猜测某些 char 在默认词典中找不到，然后会尝试到 parentDict 寻找。但默认词典是没有 parentDict 的，所以导致 es 报告 null pointer exception。