### PR TITLE
(fix) Run test query to recall dead mysql connections

### DIFF
--- a/src/main/java/com/chenlb/mmseg4j/db/AppWordDBLoader.java
+++ b/src/main/java/com/chenlb/mmseg4j/db/AppWordDBLoader.java
@@ -71,6 +71,7 @@ public class AppWordDBLoader {
             ds.setPassword(getEnv("JDBC_PASSWORD"));
             ds.setMaxPoolSize(Integer.parseInt(getEnv("JDBC_MAX_POOL_SIZE", "300")));
             ds.setMinPoolSize(Integer.parseInt(getEnv("JDBC_MIN_POOL_SIZE", "3")));
+            ds.setPreferredTestQuery("SELECT 1");
         }
         catch (Exception e) {
             log.error("Create datasource failed.", e);


### PR DESCRIPTION
某些不活跃的链接，可能被服务端单方面 kill 。当这些链接再次发起请求的时候会发生异常："Communications link failure. The last packet sent successfully to the server was 0 milliseconds ago." 。

我们需要执行测试查询，来将这些链接回收。