### PR TITLE
(fix) startOffset must not go backwards for array field

### DIFF
--- a/src/main/java/com/chenlb/mmseg4j/MMSeg.java
+++ b/src/main/java/com/chenlb/mmseg4j/MMSeg.java
@@ -51,6 +51,9 @@ public class MMSeg {
 		reader.unread(data);
 	}
 
+	public int getReadIdx() {
+		return readedIdx;
+	}
 	
 	public Word next() throws IOException {
 		//先从缓存中取

--- a/src/main/java/com/chenlb/mmseg4j/analysis/MMSegTokenizer.java
+++ b/src/main/java/com/chenlb/mmseg4j/analysis/MMSegTokenizer.java
@@ -19,6 +19,15 @@ public class MMSegTokenizer extends Tokenizer {
 	private OffsetAttribute offsetAtt;
 	private TypeAttribute typeAtt;
 
+	/**
+	 * The last offset
+	 * 
+	 * For multi-value field, e.g. `["图书管" "图书"]`, lucene expects the offset
+	 * going incrementally, instead of restarting from zero. So we have to
+	 * remember the last offset and add it when jumping to next value.
+	 */
+	private int lastOffset = 0;
+
 	public MMSegTokenizer(Seg seg) {
 		super();
 		mmSeg =new ThreadLocal<>();
@@ -29,12 +38,26 @@ public class MMSegTokenizer extends Tokenizer {
 		typeAtt = addAttribute(TypeAttribute.class);
 	}
 
+	@Override
 	public void reset() throws IOException {
         super.reset();
 		//lucene 4.0
 		//org.apache.lucene.analysis.Tokenizer.setReader(Reader)
 		//setReader 自动被调用, input 自动被设置。
 		mmSeg.get().reset(input);
+	}
+
+	/**
+	 * End of the tokenize for a field
+	 */
+	@Override
+	public void end() throws IOException {
+		super.end();
+
+		offsetAtt.setOffset(lastOffset, lastOffset);
+
+		// all tokens from field are consumed, reset to zero
+		lastOffset = 0;
 	}
 
 /*//lucene 2.9 以下
@@ -68,11 +91,11 @@ public class MMSegTokenizer extends Tokenizer {
 			//termAtt.setTermBuffer(word.getSen(), word.getWordOffset(), word.getLength());
 			//lucene 3.1
 			termAtt.copyBuffer(word.getSen(), word.getWordOffset(), word.getLength());
-			offsetAtt.setOffset(word.getStartOffset(), word.getEndOffset());
+			offsetAtt.setOffset(lastOffset+word.getStartOffset(), lastOffset + word.getEndOffset());
 			typeAtt.setType(word.getType());
 			return true;
 		} else {
-			end();
+			lastOffset += mmSeg.get().getReadIdx() + 1;
 			return false;
 		}
 	}


### PR DESCRIPTION
修复新版 lucene 关于 startOffset must not go backwards 的异常，参考： https://github.com/hankcs/hanlp-lucene-plugin/issues/27